### PR TITLE
feat: game API

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
+import { GamesModule } from './games/games.module';
 
 @Module({
-  imports: [AuthModule, UsersModule],
+  imports: [AuthModule, UsersModule, GamesModule],
   controllers: [],
   providers: [],
 })

--- a/backend/src/db/migrations/003_games.sql
+++ b/backend/src/db/migrations/003_games.sql
@@ -1,0 +1,23 @@
+-- Games table for match history
+CREATE TABLE IF NOT EXISTS games (
+  id TEXT PRIMARY KEY,
+  player1_id TEXT NOT NULL REFERENCES users(uuid) ON DELETE CASCADE,
+  player2_id TEXT REFERENCES users(uuid) ON DELETE SET NULL,
+  winner_id TEXT REFERENCES users(uuid) ON DELETE SET NULL,
+  player1_score INTEGER NOT NULL DEFAULT 0,
+  player2_score INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'waiting'
+    CHECK(status IN ('waiting', 'playing', 'finished', 'cancelled')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  finished_at TEXT
+);
+
+-- プレイヤーごとの試合履歴検索用
+CREATE INDEX IF NOT EXISTS idx_games_player1 ON games(player1_id);
+CREATE INDEX IF NOT EXISTS idx_games_player2 ON games(player2_id);
+
+-- ステータス別検索用（マッチメイキング、進行中ゲーム）
+CREATE INDEX IF NOT EXISTS idx_games_status ON games(status);
+
+-- 作成日時順ソート用
+CREATE INDEX IF NOT EXISTS idx_games_created_at ON games(created_at DESC);

--- a/backend/src/games/games.controller.ts
+++ b/backend/src/games/games.controller.ts
@@ -1,0 +1,78 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Param,
+  Body,
+  Query,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { GamesService } from './games.service';
+import type {
+  CreateGameInput,
+  StartGameInput,
+  FinishGameInput,
+  GameStatus,
+} from '../model/game.model';
+
+@Controller('api/games')
+export class GamesController {
+  constructor(private readonly gamesService: GamesService) {}
+
+  @Post()
+  create(@Body() input: CreateGameInput) {
+    return this.gamesService.create(input);
+  }
+
+  @Get('waiting')
+  findWaiting() {
+    return this.gamesService.findWaitingGames();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.gamesService.findByIdOrThrow(id);
+  }
+
+  @Get()
+  findByPlayer(
+    @Query('player_id') playerId?: string,
+    @Query('status') status?: GameStatus,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ) {
+    if (!playerId) {
+      return [];
+    }
+    return this.gamesService.findByPlayerId(playerId, {
+      status,
+      limit: limit ? parseInt(limit, 10) : undefined,
+      offset: offset ? parseInt(offset, 10) : undefined,
+    });
+  }
+
+  @Patch(':id/start')
+  start(@Param('id') id: string, @Body() input: StartGameInput) {
+    return this.gamesService.start(id, input);
+  }
+
+  @Patch(':id/finish')
+  finish(@Param('id') id: string, @Body() input: FinishGameInput) {
+    return this.gamesService.finish(id, input);
+  }
+
+  @Patch(':id/cancel')
+  @HttpCode(HttpStatus.OK)
+  cancel(@Param('id') id: string) {
+    return this.gamesService.cancel(id);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.OK)
+  delete(@Param('id') id: string) {
+    return { deleted: !!this.gamesService.deleteById(id) };
+  }
+}

--- a/backend/src/games/games.module.ts
+++ b/backend/src/games/games.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { GamesController } from './games.controller';
+import { GamesService } from './games.service';
+
+@Module({
+  controllers: [GamesController],
+  providers: [GamesService],
+  exports: [GamesService],
+})
+export class GamesModule {}

--- a/backend/src/games/games.service.ts
+++ b/backend/src/games/games.service.ts
@@ -1,0 +1,259 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { getDatabase } from '../db/database';
+import type {
+  Game,
+  GameStatus,
+  CreateGameInput,
+  StartGameInput,
+  FinishGameInput,
+} from '../model/game.model';
+
+@Injectable()
+export class GamesService {
+  /**
+   * 新規ゲームを作成
+   * player2_id 指定なし → waiting、指定あり → playing
+   */
+  create(input: CreateGameInput): Game {
+    const db = getDatabase();
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    const status: GameStatus = input.player2_id ? 'playing' : 'waiting';
+
+    const stmt = db.prepare(`
+      INSERT INTO games (id, player1_id, player2_id, status, created_at)
+      VALUES (?, ?, ?, ?, ?)
+      RETURNING *
+    `);
+
+    try {
+      return stmt.get(id, input.player1_id, input.player2_id ?? null, status, now) as Game;
+    } catch (error: unknown) {
+      if (
+        error instanceof Error &&
+        error.message.includes('FOREIGN KEY constraint failed')
+      ) {
+        throw new BadRequestException('Invalid player ID');
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * IDでゲームを検索
+   */
+  findById(id: string): Game | null {
+    const db = getDatabase();
+    const stmt = db.prepare('SELECT * FROM games WHERE id = ?');
+    const row = stmt.get(id) as Game | undefined;
+    return row ?? null;
+  }
+
+  /**
+   * IDでゲームを検索（存在しない場合は例外）
+   */
+  findByIdOrThrow(id: string): Game {
+    const game = this.findById(id);
+    if (!game) {
+      throw new NotFoundException(`Game not found: ${id}`);
+    }
+    return game;
+  }
+
+  /**
+   * プレイヤーの試合履歴を取得
+   */
+  findByPlayerId(
+    playerId: string,
+    options?: { status?: GameStatus; limit?: number; offset?: number },
+  ): Game[] {
+    const db = getDatabase();
+    const params: (string | number)[] = [playerId, playerId];
+    let sql = 'SELECT * FROM games WHERE (player1_id = ? OR player2_id = ?)';
+
+    if (options?.status) {
+      sql += ' AND status = ?';
+      params.push(options.status);
+    }
+
+    sql += ' ORDER BY created_at DESC';
+
+    if (options?.limit) {
+      sql += ' LIMIT ?';
+      params.push(options.limit);
+      if (options?.offset) {
+        sql += ' OFFSET ?';
+        params.push(options.offset);
+      }
+    }
+
+    const stmt = db.prepare(sql);
+    return stmt.all(...params) as Game[];
+  }
+
+  /**
+   * 待機中ゲーム一覧（マッチメイキング用、FIFO順）
+   */
+  findWaitingGames(): Game[] {
+    const db = getDatabase();
+    const stmt = db.prepare(
+      "SELECT * FROM games WHERE status = 'waiting' ORDER BY created_at ASC",
+    );
+    return stmt.all() as Game[];
+  }
+
+  /**
+   * ゲーム開始: player2 が参加して playing 状態へ
+   */
+  start(id: string, input: StartGameInput): Game {
+    const game = this.findByIdOrThrow(id);
+
+    if (game.status !== 'waiting') {
+      throw new ConflictException(
+        `Game is not in waiting status: ${game.status}`,
+      );
+    }
+    if (game.player1_id === input.player2_id) {
+      throw new BadRequestException('Cannot play against yourself');
+    }
+
+    const db = getDatabase();
+    const stmt = db.prepare(`
+      UPDATE games SET player2_id = ?, status = 'playing'
+      WHERE id = ?
+      RETURNING *
+    `);
+
+    try {
+      return stmt.get(input.player2_id, id) as Game;
+    } catch (error: unknown) {
+      if (
+        error instanceof Error &&
+        error.message.includes('FOREIGN KEY constraint failed')
+      ) {
+        throw new BadRequestException('Invalid player2 ID');
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * スコア変動を計算する
+   * 勝者と敗者の現在のスコアに基づいて、それぞれの変動値を返す
+   *
+   * TODO: 現在は固定値。ELOレーティング等に変更する場合はここを修正
+   */
+  calculateScoreChange(
+    _winnerScore: number,
+    _loserScore: number,
+  ): { winnerDelta: number; loserDelta: number } {
+    return { winnerDelta: 25, loserDelta: -25 };
+  }
+
+  /**
+   * ゲーム終了: スコアと勝者を記録し、プレイヤーのstatsを更新
+   * トランザクション内でゲーム更新とstats更新を原子的に実行
+   */
+  finish(id: string, input: FinishGameInput): Game {
+    const game = this.findByIdOrThrow(id);
+
+    if (game.status !== 'playing') {
+      throw new ConflictException(
+        `Game is not in playing status: ${game.status}`,
+      );
+    }
+    if (
+      input.winner_id !== game.player1_id &&
+      input.winner_id !== game.player2_id
+    ) {
+      throw new BadRequestException('Winner must be one of the players');
+    }
+
+    const db = getDatabase();
+    const now = new Date().toISOString();
+    const loserId =
+      input.winner_id === game.player1_id
+        ? game.player2_id
+        : game.player1_id;
+
+    // 勝者・敗者の現在のスコアを取得してスコア変動を計算
+    const winnerRow = db
+      .prepare('SELECT user_score FROM users WHERE uuid = ?')
+      .get(input.winner_id) as { user_score: number } | undefined;
+    const loserRow = loserId
+      ? (db
+          .prepare('SELECT user_score FROM users WHERE uuid = ?')
+          .get(loserId) as { user_score: number } | undefined)
+      : undefined;
+
+    const { winnerDelta, loserDelta } = this.calculateScoreChange(
+      winnerRow?.user_score ?? 1000,
+      loserRow?.user_score ?? 1000,
+    );
+
+    // トランザクションでゲーム更新 + stats更新を原子的に実行
+    const finishTransaction = db.transaction(() => {
+      const updatedGame = db
+        .prepare(
+          `UPDATE games
+           SET winner_id = ?, player1_score = ?, player2_score = ?,
+               status = 'finished', finished_at = ?
+           WHERE id = ?
+           RETURNING *`,
+        )
+        .get(input.winner_id, input.player1_score, input.player2_score, now, id) as Game;
+
+      // 勝者: wins+1, user_score + winnerDelta
+      db.prepare(
+        'UPDATE users SET wins = wins + 1, user_score = user_score + ? WHERE uuid = ?',
+      ).run(winnerDelta, input.winner_id);
+
+      // 敗者: losses+1, user_score + loserDelta (最低0)
+      if (loserId) {
+        db.prepare(
+          'UPDATE users SET losses = losses + 1, user_score = MAX(0, user_score + ?) WHERE uuid = ?',
+        ).run(loserDelta, loserId);
+      }
+
+      return updatedGame;
+    });
+
+    return finishTransaction();
+  }
+
+  /**
+   * ゲームキャンセル（stats更新なし）
+   */
+  cancel(id: string): Game {
+    const game = this.findByIdOrThrow(id);
+
+    if (game.status === 'finished' || game.status === 'cancelled') {
+      throw new ConflictException(`Game already ${game.status}`);
+    }
+
+    const db = getDatabase();
+    const stmt = db.prepare(`
+      UPDATE games SET status = 'cancelled'
+      WHERE id = ?
+      RETURNING *
+    `);
+
+    return stmt.get(id) as Game;
+  }
+
+  /**
+   * ゲーム削除（RETURNING句で1操作、UsersServiceパターンに準拠）
+   */
+  deleteById(id: string): Game | null {
+    const db = getDatabase();
+    const stmt = db.prepare('DELETE FROM games WHERE id = ? RETURNING *');
+    const row = stmt.get(id) as Game | undefined;
+    return row ?? null;
+  }
+}

--- a/backend/src/model/game.model.ts
+++ b/backend/src/model/game.model.ts
@@ -1,0 +1,41 @@
+/**
+ * Game エンティティ
+ * data-model.md のスキーマに準拠
+ */
+export interface Game {
+  id: string; // UUID v4
+  player1_id: string; // users.uuid への外部キー
+  player2_id: string | null; // 待機中は null
+  winner_id: string | null; // 終了前は null
+  player1_score: number; // default 0
+  player2_score: number; // default 0
+  status: GameStatus;
+  created_at: string; // ISO 8601
+  finished_at: string | null; // 終了前は null
+}
+
+export type GameStatus = 'waiting' | 'playing' | 'finished' | 'cancelled';
+
+/**
+ * ゲーム作成時の入力データ
+ */
+export interface CreateGameInput {
+  player1_id: string;
+  player2_id?: string; // 指定なしで waiting 状態
+}
+
+/**
+ * ゲーム開始時の入力データ（player2 参加）
+ */
+export interface StartGameInput {
+  player2_id: string;
+}
+
+/**
+ * ゲーム終了時の入力データ
+ */
+export interface FinishGameInput {
+  winner_id: string;
+  player1_score: number;
+  player2_score: number;
+}


### PR DESCRIPTION
1人のプレーヤーが部屋を作って、そこに相手がJOINする形

ゲーム終了時に勝者のwins+1/score+25、敗者のlosses+1/score-25が自動更新 将来的にはELOレーティングとかのスコアリングとかも検討
```bash
cd backend && pnpm run start:dev

sqlite3 data/pong.db ".schema games"

curl -X POST http://localhost:3001/api/auth/register \
  -H "Content-Type: application/json" \
  -d '{"email":"p1@test.com","password":"test1234","display_name":"Player1"}'

curl -X POST http://localhost:3001/api/games \
  -H "Content-Type: application/json" \
  -d '{"player1_id":"<uuid>"}'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added game creation and matchmaking capabilities for players to initiate matches
* Implemented game discovery with advanced filtering by player and status, plus pagination support
* Added complete game lifecycle management with start, finish, and cancel operations
* Integrated automatic player statistics tracking for wins, losses, and scores

<!-- end of auto-generated comment: release notes by coderabbit.ai -->